### PR TITLE
Add admin view to reset all companies

### DIFF
--- a/itdagene/app/company/__init__.py
+++ b/itdagene/app/company/__init__.py
@@ -1,9 +1,15 @@
 from django.utils.translation import ugettext_lazy as _
 
+COMPANY_STATUS_NOT_CONTACTED = 0
+COMPANY_STATUS_CONTACTED = 4
+COMPANY_STATUS_NOT_INTERESTED = 1
+COMPANY_STATUS_INTERESTED = 2
+COMPANY_STATUS_SIGNED = 3
+
 COMPANY_STATUS = (
-    (0, _("Not contacted")),
-    (4, _("Contacted")),
-    (1, _("Not interested")),
-    (2, _("Interested")),
-    (3, _("Signed")),
+    (COMPANY_STATUS_NOT_CONTACTED, _("Not contacted")),
+    (COMPANY_STATUS_CONTACTED, _("Contacted")),
+    (COMPANY_STATUS_NOT_INTERESTED, _("Not interested")),
+    (COMPANY_STATUS_INTERESTED, _("Interested")),
+    (COMPANY_STATUS_SIGNED, _("Signed")),
 )

--- a/itdagene/app/itdageneadmin/templates/admin/companies_reset.html
+++ b/itdagene/app/itdageneadmin/templates/admin/companies_reset.html
@@ -9,7 +9,7 @@
             <h3 class="box-title">{% trans "Danger Zone" %}</h3>
         </div>
         <div class="box-body">
-             <form method="post" action="{% url "itdagene.itdageneadmin.companies_reset" %}">
+          <form method="post" onsubmit="return confirm('{% trans "Are you sure?" %}')" action="{% url "itdagene.itdageneadmin.companies_reset" %}">
                 {% csrf_token %}
                 <p>{% blocktrans %}Are you sure you want to purge the company data?
                   This will clear all year specfic fields on all companies. This includes:{% endblocktrans %}</p>

--- a/itdagene/app/itdageneadmin/templates/admin/companies_reset.html
+++ b/itdagene/app/itdageneadmin/templates/admin/companies_reset.html
@@ -1,0 +1,29 @@
+{% extends "base_admin.html" %}
+{% load i18n %}
+
+{% block content %}
+<div class="row">
+<div class="col-lg-12">
+    <div class="box box-danger box-solid">
+        <div class="box-header">
+            <h3 class="box-title">{% trans "Danger Zone" %}</h3>
+        </div>
+        <div class="box-body">
+             <form method="post" action="{% url "itdagene.itdageneadmin.companies_reset" %}">
+                {% csrf_token %}
+                <p>{% blocktrans %}Are you sure you want to purge the company data?
+                  This will clear all year specfic fields on all companies. This includes:{% endblocktrans %}</p>
+                <ul>
+                  <li>{% trans "Company status" %}</li>
+                  <li>{% trans "Itdagene contact" %}</li>
+                  <li>{% trans "Current package" %}</li>
+                  <li>{% trans "Waiting lists" %}</li>
+                  <li>{% trans "Collaborator status" %}</li>
+                </ul>
+                <p><button type="submit" class="btn btn-danger">{% trans "Reset companies" %}</button></p>
+            </form>
+        </div>
+    </div>
+</div>
+</div>
+{% endblock %}

--- a/itdagene/app/itdageneadmin/templates/admin/dashboard.html
+++ b/itdagene/app/itdageneadmin/templates/admin/dashboard.html
@@ -2,6 +2,13 @@
 {% load i18n %}
 
 {% block content %}
-    <div class="row">
+<div class="row">
+<div class="col-lg-12">
+    <div class="box box-solid">
+        <div class="box-body">
+            <a href="{% url "itdagene.itdageneadmin.companies_reset" %}" class="btn btn-danger">{% trans "Reset companies" %}</a>
+        </div>
     </div>
+</div>
+</div>
 {% endblock %}

--- a/itdagene/app/itdageneadmin/urls.py
+++ b/itdagene/app/itdageneadmin/urls.py
@@ -1,5 +1,11 @@
 from django.urls import re_path
-from itdagene.app.itdageneadmin.views import groups, landing_page, log, preferences
+from itdagene.app.itdageneadmin.views import (
+    companies_reset,
+    groups,
+    landing_page,
+    log,
+    preferences,
+)
 
 urlpatterns = [
     re_path(r"^$", landing_page, name="itdagene.itdageneadmin.landing_page"),
@@ -24,5 +30,10 @@ urlpatterns = [
         r"^preferences/$",
         preferences.edit,
         name="itdagene.itdageneadmin.preferences.edit",
+    ),
+    re_path(
+        r"^companies_reset/$",
+        companies_reset,
+        name="itdagene.itdageneadmin.companies_reset",
     ),
 ]

--- a/itdagene/app/itdageneadmin/views/__init__.py
+++ b/itdagene/app/itdageneadmin/views/__init__.py
@@ -1,5 +1,8 @@
-from django.shortcuts import render
+from django.contrib.messages import SUCCESS, add_message
+from django.shortcuts import redirect, render, reverse
 from django.utils.translation import ugettext_lazy as _
+from itdagene.app.company import COMPANY_STATUS_NOT_CONTACTED
+from itdagene.app.company.models import Company
 from itdagene.core.decorators import superuser_required
 from itdagene.core.log.models import LogItem
 
@@ -31,4 +34,25 @@ def log(request, first_object=0):
             "next": int(first_object) + 41,
             "title": _("Log"),
         },
+    )
+
+
+@superuser_required()
+def companies_reset(request):
+
+    if request.method == "POST":
+        all_companies = Company.objects.all()
+        for company in all_companies:
+            company.status = COMPANY_STATUS_NOT_CONTACTED
+            company.contact = None
+            company.package = None
+            company.waiting_for_package.clear()
+            company.is_collaborator = False
+            company.save()
+
+        add_message(request, SUCCESS, _("Companies reset"))
+        return redirect(reverse("itdagene.itdageneadmin.landing_page"))
+
+    return render(
+        request, "admin/companies_reset.html", {"title": _("Reset companies")}
     )

--- a/itdagene/app/itdageneadmin/views/__init__.py
+++ b/itdagene/app/itdageneadmin/views/__init__.py
@@ -41,14 +41,13 @@ def log(request, first_object=0):
 def companies_reset(request):
 
     if request.method == "POST":
-        all_companies = Company.objects.all()
-        for company in all_companies:
-            company.status = COMPANY_STATUS_NOT_CONTACTED
-            company.contact = None
-            company.package = None
-            company.waiting_for_package.clear()
-            company.is_collaborator = False
-            company.save()
+        Company.objects.all().update(
+            status=COMPANY_STATUS_NOT_CONTACTED,
+            contact=None,
+            package=None,
+            is_collaborator=False,
+        )
+        Company.waiting_for_package.through.objects.all().delete()
 
         add_message(request, SUCCESS, _("Companies reset"))
         return redirect(reverse("itdagene.itdageneadmin.landing_page"))


### PR DESCRIPTION
Adds an admin view to reset all year-specific fields on all companies.
On the `/admin` route:
![image](https://user-images.githubusercontent.com/42850232/69344937-870f0380-0c70-11ea-9652-11993f61e9f2.png)

Confirm page:
![image](https://user-images.githubusercontent.com/42850232/69345076-cccbcc00-0c70-11ea-8025-3d9b0b2341db.png)
