### PR TITLE
Fix joblisting slug length & pages query

### DIFF
--- a/itdagene/app/career/migrations/0018_gen_slug.py
+++ b/itdagene/app/career/migrations/0018_gen_slug.py
@@ -8,7 +8,7 @@ def gen_slug(apps, schema_editor):
     Joblisting = apps.get_model("career", "Joblisting")
     for joblisting in Joblisting.objects.all():
         joblisting.slug = slugify(
-            f"{joblisting.company.name} {joblisting.title} {joblisting.date_created.strftime('%Y-%m-%d')}"
+            f"{joblisting.company.name} {joblisting.date_created.strftime('%Y-%m-%d')}"
         )
         joblisting.save()
 

--- a/itdagene/app/career/migrations/0019_auto_20200121_1538.py
+++ b/itdagene/app/career/migrations/0019_auto_20200121_1538.py
@@ -5,14 +5,12 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ('career', '0018_gen_slug'),
-    ]
+    dependencies = [("career", "0018_gen_slug")]
 
     operations = [
         migrations.AlterField(
-            model_name='joblisting',
-            name='slug',
-            field=models.SlugField(editable=False, unique=True),
-        ),
+            model_name="joblisting",
+            name="slug",
+            field=models.SlugField(editable=False, unique=True, max_length=100),
+        )
     ]

--- a/itdagene/app/career/models.py
+++ b/itdagene/app/career/models.py
@@ -52,7 +52,7 @@ class Joblisting(BaseModel):
     is_active = models.BooleanField(verbose_name=_("active"), default=True)
     frontpage = models.BooleanField(_("Frontpage"), default=False)
     hide_contactinfo = models.BooleanField(_("Hide contact info"), default=False)
-    slug = models.SlugField(editable=False, unique=True)
+    slug = models.SlugField(editable=False, unique=True, max_length=100)
 
     def __str__(self):
         return self.title

--- a/itdagene/graphql/query.py
+++ b/itdagene/graphql/query.py
@@ -98,7 +98,7 @@ class Query(graphene.ObjectType):
         Page,
         language=graphene.String(default_value="nb"),
         slugs=graphene.List(graphene.NonNull(graphene.String), default_value=None),
-        infopage=graphene.NonNull(graphene.Boolean, default_value=None),
+        infopage=graphene.Boolean(),
         description="Get info page.\n\n Each page identified with "
         + "a slug can be translated into multiple languages. "
         + "Each entity is identified by an id or the unique together pair (slug, language). "


### PR DESCRIPTION
Whoops!
The slugfied has a default max length of 50 chars, so migrations failed. Increasing to 100 should be fine, and will avoid further issues.

Also the `infopage` field on the pages query was set to NonNull :thinking:.