### PR TITLE
Change event filter to filter on current year

### DIFF
--- a/itdagene/app/events/views.py
+++ b/itdagene/app/events/views.py
@@ -1,17 +1,17 @@
 from django.contrib.auth.decorators import permission_required
 from django.contrib.messages import SUCCESS, add_message
 from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
+
 from itdagene.app.events.forms import EventForm, EventTicketForm
 from itdagene.app.events.models import Event, Ticket
 from itdagene.core.decorators import staff_required
-from itdagene.core.models import Preference
 
 
 @staff_required()
 def list_events(request):
-    pref = Preference.current_preference()
-    events = Event.objects.filter(date__year=pref.year)
+    events = Event.objects.filter(date__year=now().year)
     return render(request, "events/base.html", {"events": events, "title": _("Events")})
 
 

--- a/itdagene/graphql/query.py
+++ b/itdagene/graphql/query.py
@@ -1,6 +1,8 @@
 import graphene
+from django.utils.timezone import now
 from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
+
 from itdagene.app.events.models import Event as ItdageneEvent
 from itdagene.core.models import Preference
 from itdagene.graphql.filters import JoblistingFilter
@@ -149,8 +151,7 @@ class Query(graphene.ObjectType):
         return info.context.count
 
     def resolve_events(self, info):
-        pref = Preference.current_preference()
-        return ItdageneEvent.objects.filter(date__year=pref.year, is_internal=False)
+        return ItdageneEvent.objects.filter(date__year=now().year, is_internal=False)
 
     def resolve_stand(self, info, slug):
         return Stand.get_queryset().get(slug=slug)


### PR DESCRIPTION
We are now hosting itdagene 2020 in 2021 so there is an edge case where
this filtering filters out all events created for the current itdagene.