### PR TITLE
Fix wrong reverse url for stand

### DIFF
--- a/itdagene/app/stands/models.py
+++ b/itdagene/app/stands/models.py
@@ -29,7 +29,7 @@ class DigitalStand(BaseModel):
     description = models.TextField(blank=True, verbose_name=_("description"))
 
     def get_absolute_url(self):
-        return reverse("itdagene.stands.digitalstand.view", args=[self.pk])
+        return reverse("itdagene.stands.view", args=[self.pk])
 
     def __str__(self):
         return str(self.company.name + "-stand")


### PR DESCRIPTION
This should fix the 500 errors some users have been getting in the admin panel.

The case is that the `notifications` uses the models `get_absolute_url()` to get the url of an object. As this was incorrect for `stands`, when someone edited a stand you created, you would get a notification, which causes a crash for the user that created the stand...