### PR TITLE
Fix invalid date error when changing year preference (Fixes #206)

### DIFF
--- a/itdagene/app/itdageneadmin/views/preferences.py
+++ b/itdagene/app/itdageneadmin/views/preferences.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from itdagene.app.itdageneadmin.forms import PreferenceForm
 from itdagene.core.models import Preference
+from datetime import datetime
 
 
 @permission_required("core.change_preference")
@@ -22,16 +23,16 @@ def edit(request):
                     year=preference.year,
                     defaults={
                         "active": True,
-                        "start_date": "%s-09-10" % preference.year,
-                        "end_date": "%s-09-11" % preference.year,
+                        "start_date": datetime.strptime("%s-09-11" % preference.year, "%Y-%m-%d"),
+                        "end_date": datetime.strptime("%s-09-12" % preference.year, "%Y-%m-%d"),
                     },
                 )
             else:
                 preference.save(log_it=False, notify_subscribers=False)
 
-            for peference_object in Preference.objects.exclude(id=preference.id):
-                peference_object.active = False
-                peference_object.save(log_it=False, notify_subscribers=False)
+            for preference_object in Preference.objects.exclude(id=preference.id):
+                preference_object.active = False
+                preference_object.save(log_it=False, notify_subscribers=False)
 
             cache.set("pref", preference)
             return redirect(reverse("itdagene.itdageneadmin.preferences.edit"))

--- a/itdagene/core/models.py
+++ b/itdagene/core/models.py
@@ -201,8 +201,8 @@ class Preference(BaseModel):
                     year=year,
                     defaults={
                         "active": True,
-                        "start_date": datetime.strptime("%s-09-11" % preference.year, "%Y-%m-%d"),
-                        "end_date": datetime.strptime("%s-09-12" % preference.year, "%Y-%m-%d"),
+                        "start_date": datetime.strptime("%s-09-11" % year, "%Y-%m-%d"),
+                        "end_date": datetime.strptime("%s-09-12" % year, "%Y-%m-%d"),
                     },
                 )
                 pref.active = True

--- a/itdagene/core/models.py
+++ b/itdagene/core/models.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from itdagene.core.auth import get_current_user
 from raven import breadcrumbs
 from social_core.exceptions import AuthForbidden
+from datetime import datetime
 
 
 def user_default_year():
@@ -200,8 +201,8 @@ class Preference(BaseModel):
                     year=year,
                     defaults={
                         "active": True,
-                        "start_date": "%s-09-10" % year,
-                        "end_date": "%s-09-11" % year,
+                        "start_date": datetime.strptime("%s-09-11" % preference.year, "%Y-%m-%d"),
+                        "end_date": datetime.strptime("%s-09-12" % preference.year, "%Y-%m-%d"),
                     },
                 )
                 pref.active = True

--- a/itdagene/core/models.py
+++ b/itdagene/core/models.py
@@ -221,8 +221,8 @@ class Preference(BaseModel):
                 year=year,
                 defaults={
                     "active": True,
-                    "start_date": "%s-09-10" % year,
-                    "end_date": "%s-09-11" % year,
+                    "start_date": datetime.strptime("%s-09-11" % year, "%Y-%m-%d"),
+                    "end_date": datetime.strptime("%s-09-12" % year, "%Y-%m-%d"),
                 },
             )
             pref.active = True


### PR DESCRIPTION
Fixes invalid date format by converting the dates to actual date objects when passing as default value.

See [DateField docs](https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.DateField):
> A date, represented in Python by a datetime.date instance