### PR TITLE
Filter out inactive boardmembers

### DIFF
--- a/itdagene/graphql/object_types.py
+++ b/itdagene/graphql/object_types.py
@@ -270,8 +270,7 @@ class MetaData(DjangoObjectType):
 
     def resolve_board_members(self, info):
         return (
-            ItdageneUser.objects.filter(year=self.year)
-            .filter(is_active=True)
+            ItdageneUser.objects.filter(year=self.year, is_active=True)
             .all()
             .prefetch_related("groups")
         )

--- a/itdagene/graphql/object_types.py
+++ b/itdagene/graphql/object_types.py
@@ -270,7 +270,10 @@ class MetaData(DjangoObjectType):
 
     def resolve_board_members(self, info):
         return (
-            ItdageneUser.objects.filter(year=self.year).all().prefetch_related("groups")
+            ItdageneUser.objects.filter(year=self.year)
+            .filter(is_active=True)
+            .all()
+            .prefetch_related("groups")
         )
 
     class Meta:


### PR DESCRIPTION
When soft-deleting a user we set the is_active field to False.

As we don't want to show inactive users on the about-us page, we need to filter out the inactive members, as done in this PR. 