### PR TITLE
Upgrade to GitHub-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: django
+    versions:
+    - ">= 3.a"
+    - "< 4"


### PR DESCRIPTION
Dependabot Preview [has been shut down](https://github.blog/2021-04-29-goodbye-dependabot-preview-hello-dependabot/) as of August 3rd, 2021. In order to keep getting Dependabot updates, we're migrating to GitHub-native Dependabot.