### PR TITLE
Update config files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
 [tool.black]
 line-length = 88
 target-version = ["py37"]
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88
+skip_glob = [
+    "**/templates/*",
+    ".tox/*",
+    "node_modules/*",
+    "venv/*",
+    "itdagene/assets/*",
+    "itdagene/locale/*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,9 @@ line-length = 88
 target-version = ["py37"]
 
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 88
+profile = "black"
+combine_as_imports = true
+lines_after_imports = 2
 skip_glob = [
     "**/templates/*",
     ".tox/*",

--- a/requirements/flake8.txt
+++ b/requirements/flake8.txt
@@ -1,1 +1,2 @@
 flake8==3.7.9
+flake8-bugbear==20.1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,13 @@ exclude =
     itdagene/assets/*
     itdagene/locale/*
     itdagene/settings/*
-extend-select = B950
+extend-select =
+    # All bugbear opinionated warnings
+    B9
 extend-ignore =
+    # Whitespace before ':' is not PEP8 compliant
     E203
+    # Line too long (+3). Overridden by B950
     E501
-    E701
+    # Line break occurred before a binary operator
     W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,17 +9,9 @@ exclude =
     itdagene/assets/*
     itdagene/locale/*
     itdagene/settings/*
-ignore =
+extend-select = B950
+extend-ignore =
     E203
     E501
     E701
     W503
-
-[isort]
-multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 0
-use_parentheses = True
-ensure_newline_before_comments = True
-line_length = 88
-skip = .tox

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements/black.txt
 commands =
-    black -l 88 -t py37 itdagene
+    black itdagene
 
 [testenv:flake8]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,3 @@
-[flake8]
-max-line-length = 100
-exclude =
-    **/migrations/*
-    **/templates/*
-    .tox/*
-    node_modules/*
-    venv/*
-    itdagene/assets/*
-    itdagene/locale/*
-    itdagene/settings/*
-
 [tox]
 envlist =
     python3.7
@@ -49,7 +37,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements/black.txt
 commands =
-    black itdagene
+    black -l 88 -t py37 itdagene
 
 [testenv:flake8]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements/isort.txt
 commands =
-    isort --df -c itdagene
+    isort itdagene
 
 [testenv:black]
 setenv =


### PR DESCRIPTION
* Move isort config to pyproject.toml, as this is more common.
* Replace isort skip with skip_glob keyword to be more flexible.
* Add flake8-bugbear requirement, as recommended by black.
* Add B9xx check in flake8, to make it more explicit.
* Remove redundant flake8 config from tox.ini, as tox uses setup.cfg by default.