### PR TITLE
Fix bdb crash

### DIFF
--- a/itdagene/app/company/views/__init__.py
+++ b/itdagene/app/company/views/__init__.py
@@ -68,7 +68,7 @@ def view(request: HttpRequest, id: Any) -> HttpResponse:
     company = get_object_or_404(
         Company.objects.select_related().prefetch_related(), pk=id
     )
-    evaluation, _ = Evaluation.objects.get_or_create(
+    evaluation, _created = Evaluation.objects.get_or_create(
         company=company, preference=Preference.current_preference()
     )
     return render(


### PR DESCRIPTION
Because of `from django.utils.translation import gettext_lazy as _` the previous renaming of a unused variable to `_` caused a crash when invoking `_("Company")`.

We should probably double check this wherever an import is imported as `_` to avoid similar situations elsewhere in the future. 