### PR TITLE
remove notifications with no content_object. this stops admin page fr…

### DIFF
--- a/itdagene/core/notifications/middleware.py
+++ b/itdagene/core/notifications/middleware.py
@@ -16,6 +16,9 @@ class NotificationsMiddleware(MiddlewareMixin):
             ).all()
 
             for notification in notifications:
+                if not notification.content_object:
+                    notification.delete()
+
                 if notification.content_object.get_absolute_url() == path:
                     notification.users.remove(user)
                     if notification.users.count == 0:


### PR DESCRIPTION
Prohibit admin page from crashing due to Notifications Middleware attempting to access notification.object_content in cases where content_object is None