### PR TITLE
remove notifications with no content_object. this stops admin page fr…

### DIFF
--- a/itdagene/core/notifications/middleware.py
+++ b/itdagene/core/notifications/middleware.py
@@ -16,6 +16,9 @@ class NotificationsMiddleware(MiddlewareMixin):
             ).all()
 
             for notification in notifications:
+                if not notification.content_object:
+                    notification.delete()
+                    continue
                 if notification.content_object.get_absolute_url() == path:
                     notification.users.remove(user)
                     if notification.users.count == 0:


### PR DESCRIPTION
…om crashing due to code trying to fetch attributes of None object